### PR TITLE
Fix main branch name in scripts

### DIFF
--- a/runner.sh
+++ b/runner.sh
@@ -3,7 +3,7 @@ cd base
 
 # Get template
 echo "Getting template files..."
-git clone --branch stable https://github.com/daleal/station.git &> /dev/null
+git clone --branch master https://github.com/daleal/station.git &> /dev/null
 cd station
 
 # Run python script


### PR DESCRIPTION
# Bugfix: Fix main branch name in scripts

## Description

Fix stable branch leftover name on the clone script.

## Requirements

None.

## Additional changes

None.
