### PR TITLE
Fix Turbolinks interaction with Vue

### DIFF
--- a/{{cookiecutter.project_kebab}}/app/javascript/packs/vue_pack.js
+++ b/{{cookiecutter.project_kebab}}/app/javascript/packs/vue_pack.js
@@ -5,7 +5,9 @@ import App from '../app.vue'
 Vue.use(TurbolinksAdapter)
 
 document.addEventListener('turbolinks:load', () => {
-  new Vue({
-    render: (h) => h(App),
-  }).$mount('#hello');
+  if (document.getElementById('hello')) {
+    new Vue({
+      render: (h) => h(App),
+    }).$mount('#hello');
+  }
 })

--- a/{{cookiecutter.project_kebab}}/app/views/hello/say_hello.html.erb
+++ b/{{cookiecutter.project_kebab}}/app/views/hello/say_hello.html.erb
@@ -1,1 +1,1 @@
-<div id='hello'></div>
+<div hidden id='hello'></div>

--- a/{{cookiecutter.project_kebab}}/app/views/hello/say_hello.html.erb
+++ b/{{cookiecutter.project_kebab}}/app/views/hello/say_hello.html.erb
@@ -1,3 +1,1 @@
-<%= javascript_pack_tag 'hello_vue' %>
-
 <div id='hello'></div>

--- a/{{cookiecutter.project_kebab}}/app/views/layouts/application.html.erb
+++ b/{{cookiecutter.project_kebab}}/app/views/layouts/application.html.erb
@@ -7,6 +7,7 @@
 
     <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
+    <%= javascript_pack_tag 'vue_pack' %>
   </head>
 
   <body>


### PR DESCRIPTION
# Bugfix: Fix Turbolinks interaction with Vue

## Description

This pull request loads the Vue pack in the HTML `head` element to avoid bad interactions with Turbolinks.

## Requirements

None.

## Additional changes

None.
